### PR TITLE
feat(input): add label styling properties for input components

### DIFF
--- a/src/app/shared/atoms/input/input.component.html
+++ b/src/app/shared/atoms/input/input.component.html
@@ -1,10 +1,16 @@
 <div class="flex flex-col w-full">
-  <div class="flex items-center gap-2 mb-1">
+  <div
+    class="flex items-center gap-2 mb-1"
+    [ngClass]="{
+      'justify-start': labelAlignment() === 'left',
+      'justify-center': labelAlignment() === 'center',
+      'justify-end': labelAlignment() === 'right',
+    }">
     @if (labelIcon()) {
       <fa-icon [icon]="labelIcon()!" class="text-[#334EAC]"></fa-icon>
     }
 
-    <span class="text-sm font-medium text-[#334EAC]">
+    <span [ngClass]="[labelSize(), labelFont()]" [style.color]="labelColor()">
       {{ label() }}
     </span>
   </div>

--- a/src/app/shared/atoms/input/input.component.ts
+++ b/src/app/shared/atoms/input/input.component.ts
@@ -36,6 +36,10 @@ export class InputComponent implements ControlValueAccessor {
   readonly backgroundColor = input('#ffffff');
   readonly customClass = input<string | Record<string, boolean>>('');
   readonly labelIcon = input<IconDefinition | null>(null);
+  readonly labelColor = input<string>('#334EAC');
+  readonly labelSize = input<string>('text-sm');
+  readonly labelFont = input<string>('font-medium');
+  readonly labelAlignment = input<'left' | 'center' | 'right'>('left');
 
   // Password visibility properties
   showPassword = false;

--- a/src/app/shared/molecules/input-field/input-field.component.html
+++ b/src/app/shared/molecules/input-field/input-field.component.html
@@ -8,6 +8,10 @@
     [height]="height()"
     [customClass]="customClass() ?? ''"
     [labelIcon]="labelIcon() ?? null"
+    [labelColor]="labelColor()"
+    [labelSize]="labelSize()"
+    [labelFont]="labelFont()"
+    [labelAlignment]="labelAlignment()"
     [formControl]="control">
   </input-atom>
 

--- a/src/app/shared/molecules/input-field/input-field.component.ts
+++ b/src/app/shared/molecules/input-field/input-field.component.ts
@@ -282,4 +282,27 @@ export class InputFieldComponent implements OnInit {
 
     return null;
   }
+  /**
+   * Label color for the input field.
+   * @param '#334EAC' - Default color for the label.
+   */
+  readonly labelColor = input<string>('#334EAC');
+
+  /**
+   * Label font size for the input field.
+   * @param 'text-sm' - Default font size for the label.
+   */
+  readonly labelSize = input<string>('text-sm');
+
+  /**
+   * Label font weight for the input field.
+   * @param 'font-medium' - Default font weight for the label.
+   */
+  readonly labelFont = input<string>('font-medium');
+
+  /**
+   * Label alignment for the input field.
+   * @param 'left' - Default alignment for the label.
+   */
+  readonly labelAlignment = input<'left' | 'center' | 'right'>('left');
 }


### PR DESCRIPTION
## Actualización de molécula
Se implementó las opciones de cambiar el color, tamaño, fuente y alineación del label que acompaña al input (molécula - InputField).
![image](https://github.com/user-attachments/assets/a9dc3b84-ce05-475c-8e74-a4ee1bb8ffb6)